### PR TITLE
Bug Fix: PUTSP

### DIFF
--- a/js/lc3_core.js
+++ b/js/lc3_core.js
@@ -678,6 +678,8 @@ LC3.prototype.updateIO = function() {
             type: 'keyout',
             value: keyPacked,
         }
+        console.log(ev)
+        console.log(evPacked);
         this.notifyListeners(ev);
         if(evPacked !== 0) this.notifyListeners(evPacked);
         this.setMemory(this.dsr, dsrValue | 0x8000);

--- a/js/lc3_core.js
+++ b/js/lc3_core.js
@@ -672,7 +672,14 @@ LC3.prototype.updateIO = function() {
             type: 'keyout',
             value: key,
         };
+        // Accommodate for packed input
+        var keyPacked = (this.getMemory(this.ddr) & 0xFF00) >> 8;
+        var evPacked = {
+            type: 'keyout',
+            value: keyPacked,
+        }
         this.notifyListeners(ev);
+        if(evPacked !== 0) this.notifyListeners(evPacked);
         this.setMemory(this.dsr, dsrValue | 0x8000);
     }
 };

--- a/js/lc3_core.js
+++ b/js/lc3_core.js
@@ -678,8 +678,6 @@ LC3.prototype.updateIO = function() {
             type: 'keyout',
             value: keyPacked,
         }
-        console.log(ev)
-        console.log(evPacked);
         this.notifyListeners(ev);
         if(evPacked !== 0) this.notifyListeners(evPacked);
         this.setMemory(this.dsr, dsrValue | 0x8000);


### PR DESCRIPTION
I'm in a class that uses your simulator and our current assignment works with packed strings. Unfortunately, those don't work in this version. I've done some poking around between this version and the downloaded version and found that the issue isn't the LC-3 code itself, but instead the way output gets handled after being stored in `0xFE06`. In the current version of lc3web, only the first two bytes get read, completely ignoring the extra packed bytes. This code fixes that (albeit sort of messy).

One interesting quirk I found playing with the downloadable version is that `PUTS` and `PUTSP` have the exact same output. That is, if you give a packed string to `PUTS`, it actually parses the packed bytes correctly. I tried following the LC-3 instructions in both trap routines, and they seem to be doing the exact same thing (storing to `0xFE06`, packed or otherwise). I'm not sure if this is intentional or not, but to stay on the safe side my code emulates this. 